### PR TITLE
Create 00003.json

### DIFF
--- a/00003.json
+++ b/00003.json
@@ -1,0 +1,11 @@
+{
+    "title": "Lower the Number of Farms from 30 to 25",
+    "content": "This would lower the current number of farms receiving a mist allocation from 30 to 25. This will apply to next farm reweighting and all subsequent reweightings.",
+    "strategy": "single-choice",
+    "options": [
+        "Yes, Lower Number of Farms from 30 to 25",
+        "No, keep as-is"
+    ],
+    "snapshotBlock": "2893840",
+    "endBlock": "3010000"
+}

--- a/00003.json
+++ b/00003.json
@@ -6,6 +6,6 @@
         "Yes, Lower Number of Farms from 30 to 25",
         "No, keep as-is"
     ],
-    "snapshotBlock": "2893840",
-    "endBlock": "3010000"
+    "snapshotBlock": "2998194",
+    "endBlock": "3045246"
 }


### PR DESCRIPTION
PROPOSAL: [Lower the Number of Farms from 30 to 25]
OPTIONS:
- [Option #1] Lower Number of Farms from 30-25
- [Option #2] Keep Number of Farms as is
* Economic Impact- As there are few great projects that stand out in SmartBCH, lowering number of farms from 30 to 25 will allow for higher aprs for stronger projects thus bringing in renewed interest to mistswap. 
* Impact on users- Higher APY's for better projects means better liquidity for those projects and a more positive trading experience for users
* Expected positive impact- Less farms that are wash traded stealing farm slots from projects that deserve it
* Known potential negatives or downsides- Less amount of farms for projects to fight over
* Unknown impacts or aspects- unknown