### PR TITLE
feat: create spam filter policy committee

### DIFF
--- a/proposals/00004.json
+++ b/proposals/00004.json
@@ -6,6 +6,6 @@
         "Yes, create the spam filter policy committee",
         "No, do not create it"
     ],
-    "snapshotBlock": "3034000",
-    "endBlock": "3081052"
+    "snapshotBlock": "3027671",
+    "endBlock": "3059039"
 }

--- a/proposals/00004.json
+++ b/proposals/00004.json
@@ -1,0 +1,11 @@
+{
+    "title": "Create Spam Filter Policy Committee",
+    "content": "Create a committee of 5 people to ensure that spam tokens do not get free MIST\n\nCurrently, spam tokens are removed from farm allocations manually by Kasumi \nIn the spirit of decentralization, it would be an improvement to have this be decided by a committee of \nneutral people. The committee would be a closed group who must reach consensus on what tokens \nmeet the criteria laid out to be eliminated from the farm allocation algorithm. \n\nThe criteria chosen is simple: tokens whom use wash trading on MistSwap for MIST allocation as a primary portion of their income/business model.\n\nThese members would be: \n\n\n* CryptoCurenTay\n* Dinopawnz\n* Hans Wurschd\n* Maemon\n* Vin\n\n\nThe impact of this should increase the amount of MIST being granted to projects which are more likely to succeed. \nWhile not the perfect decentralized solution, we believe that this is currently the best compromise between decentralization and legitimate tokens / projects being removed in bad faith through our voting system as we work towards a more permanent solution in the future.\n",
+    "strategy": "single-choice",
+    "options": [
+        "Yes, create the spam filter policy committee",
+        "No, do not create it"
+    ],
+    "snapshotBlock": "3034000",
+    "endBlock": "3081052"
+}


### PR DESCRIPTION
PROPOSAL: Create Spam Filter Policy Committee 

Create a committee of 5 people to ensure that spam tokens do not get free MIST

Currently, spam tokens are removed from farm allocations manually by Kasumi 
In the spirit of decentralization, it would be an improvement to have this be decided by a committee of 
neutral people. The committee would be a closed group who must reach consensus on what tokens 
meet the criteria laid out to be eliminated from the farm allocation algorithm. 

The criteria chosen is simple: tokens whom use wash trading on MistSwap for MIST allocation as a primary portion of their income/business model.

These members would be: 


* CryptoCurenTay
* Dinopawnz
* Hans Wurschd
* Maemon
* Vin


The impact of this should increase the amount of MIST being granted to projects which are more likely to succeed. 
While not the perfect decentralized solution, we believe that this is currently the best compromise between decentralization and legitimate tokens / projects being removed in bad faith through our voting system as we work towards a more permanent solution in the future.